### PR TITLE
Fix test failures by adding missing Menu facade alias

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -115,6 +115,7 @@ abstract class TestCase extends Orchestra
     {
         return [
             'Field' => \Juzaweb\Modules\Core\Facades\Field::class,
+            'Menu' => \Juzaweb\Modules\Core\Facades\Menu::class,
             'Module' => \Juzaweb\Modules\Core\Facades\Module::class,
             'Theme' => \Juzaweb\Modules\Core\Facades\Theme::class,
             'Widget' => \Juzaweb\Modules\Core\Facades\Widget::class,


### PR DESCRIPTION
Fixes test failures caused by a missing facade alias for `Menu` in the Orchestra Testbench configuration (`tests/TestCase.php`).

The error manifested as:
`Class "Menu" not found (View: /app/vendor/juzaweb/core/src/resources/views/layouts/components/navbar.blade.php)`

This PR adds `'Menu' => \Juzaweb\Modules\Core\Facades\Menu::class` to the `getPackageAliases` method of the base test case. All tests now pass successfully.

---
*PR created automatically by Jules for task [9788856958741561976](https://jules.google.com/task/9788856958741561976) started by @juzaweb*